### PR TITLE
SL-13 Add param to turn off DEXSeq.gff output save

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -332,14 +332,15 @@ if (params.rmats) {
 if (params.dexseq_exon) {
 
     process {
-        withName: 'DEXSEQ_ANNOTATION' {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}/dexseq_exon/annotation" },
-                mode: params.publish_dir_mode,
-                pattern: "*.gff"
-            ]
+        if (!params.skip_dexseq_gff_save) {
+            withName: 'DEXSEQ_ANNOTATION' {
+                publishDir = [
+                    path: { "${params.outdir}/${params.aligner}/dexseq_exon/annotation" },
+                    mode: params.publish_dir_mode,
+                    pattern: "*.gff"
+                ]
+            }
         }
-
         withName: 'DEXSEQ_COUNT' {
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/dexseq_exon/counts" },

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,6 +60,7 @@ params {
 
     // DEXSeq DEU
     dexseq_exon                = false
+    skip_dexseq_gff_save       = false
     gff_dexseq                 = null
     alignment_quality          = 10
     aggregation                = true


### PR DESCRIPTION
Hi,

There is currently no param that disables saving the output DEXSeq.gff. This PR adds a param called skip_dexseq_gff_save to the nextflow.config, and included this param in the modules.config to skip saving DEXSeq.gff if this param is specified. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
