### PR TITLE
Sl 15 implement featurecounts for dex seq deu

### DIFF
--- a/bin/dexseq_prepare_annotation2.py
+++ b/bin/dexseq_prepare_annotation2.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+import sys, collections, itertools, os.path, optparse, os # changed here to add sed
+
+optParser = optparse.OptionParser(
+
+   usage = "python %prog [options] <in.gtf> <out.gff>",
+
+   description=
+      "Script to prepare annotation for DEXSeq." +
+      "This script takes an annotation file in Ensembl GTF format" +
+      "and outputs a 'flattened' annotation file suitable for use " +
+      "with the count_in_exons.py script ",
+
+   epilog =
+      "Written by Simon Anders (sanders@fs.tum.de), European Molecular Biology " +
+      "Laboratory (EMBL). (c) 2010. Released under the terms of the GNU General " +
+      "Public License v3. Part of the 'DEXSeq' package. " +
+	"Modified by Vivek Bhardwaj (just a bit!) to write featurecounts gtf as an option.")
+
+optParser.add_option( "-r", "--aggregate", type="choice", dest="aggregate",
+   choices = ( "no", "yes" ), default = "yes",
+   help = "'yes' or 'no'. Indicates whether two or more genes sharing an exon should be merged into an 'aggregate gene'. If 'no', the exons that can not be assiged to a single gene are ignored." )
+
+# add option for featurecounts output
+optParser.add_option( "-f", "--featurecountsgtf", type="string", dest="fcgtf", action = "store",
+   help = "gtf file to write for featurecounts." )
+
+##
+
+(opts, args) = optParser.parse_args()
+
+if len( args ) != 2:
+   sys.stderr.write( "Script to prepare annotation for DEXSeq.\n\n" )
+   sys.stderr.write( "Usage: python %s <in.gtf> <out.gff>\n\n" % os.path.basename(sys.argv[0]) )
+   sys.stderr.write( "This script takes an annotation file in Ensembl GTF format\n" )
+   sys.stderr.write( "and outputs a 'flattened' annotation file suitable for use\n" )
+   sys.stderr.write( "with the count_in_exons.py script.\n" )
+   sys.exit(1)
+
+try:
+   import HTSeq
+except ImportError:
+   sys.stderr.write( "Could not import HTSeq. Please install the HTSeq Python framework\n" )
+   sys.stderr.write( "available from http://www-huber.embl.de/users/anders/HTSeq\n" )
+   sys.exit(1)
+
+
+
+
+gtf_file = args[0]
+out_file = args[1]
+
+aggregateGenes = opts.aggregate == "yes"
+
+# Step 1: Store all exons with their gene and transcript ID
+# in a GenomicArrayOfSets
+
+exons = HTSeq.GenomicArrayOfSets( "auto", stranded=True )
+for f in HTSeq.GFF_Reader( gtf_file ):
+   if f.type != "exon":
+      continue
+   f.attr['gene_id'] = f.attr['gene_id'].replace( ":", "_" )
+   exons[f.iv] += ( f.attr['gene_id'], f.attr['transcript_id'] )
+
+
+# Step 2: Form sets of overlapping genes
+
+# We produce the dict 'gene_sets', whose values are sets of gene IDs. Each set
+# contains IDs of genes that overlap, i.e., share bases (on the same strand).
+# The keys of 'gene_sets' are the IDs of all genes, and each key refers to
+# the set that contains the gene.
+# Each gene set forms an 'aggregate gene'.
+
+if aggregateGenes == True:
+   gene_sets = collections.defaultdict( lambda: set() )
+   for iv, s in exons.steps():
+      # For each step, make a set, 'full_set' of all the gene IDs occuring
+      # in the present step, and also add all those gene IDs, whch have been
+      # seen earlier to co-occur with each of the currently present gene IDs.
+      full_set = set()
+      for gene_id, transcript_id in s:
+         full_set.add( gene_id )
+         full_set |= gene_sets[ gene_id ]
+      # Make sure that all genes that are now in full_set get associated
+      # with full_set, i.e., get to know about their new partners
+      for gene_id in full_set:
+         assert gene_sets[ gene_id ] <= full_set
+         gene_sets[ gene_id ] = full_set
+
+
+# Step 3: Go through the steps again to get the exonic sections. Each step
+# becomes an 'exonic part'. The exonic part is associated with an
+# aggregate gene, i.e., a gene set as determined in the previous step,
+# and a transcript set, containing all transcripts that occur in the step.
+# The results are stored in the dict 'aggregates', which contains, for each
+# aggregate ID, a list of all its exonic_part features.
+
+aggregates = collections.defaultdict( lambda: list() )
+for iv, s in exons.steps( ):
+   # Skip empty steps
+   if len(s) == 0:
+      continue
+   gene_id = list(s)[0][0]
+   ## if aggregateGenes=FALSE, ignore the exons associated to more than one gene ID
+   if aggregateGenes == False:
+      check_set = set()
+      for geneID, transcript_id in s:
+         check_set.add( geneID )
+      if( len( check_set ) > 1 ):
+         continue
+      else:
+         aggregate_id = gene_id
+   # Take one of the gene IDs, find the others via gene sets, and
+   # form the aggregate ID from all of them
+   else:
+      assert set( gene_id for gene_id, transcript_id in s ) <= gene_sets[ gene_id ]
+      aggregate_id = '+'.join( gene_sets[ gene_id ] )
+   # Make the feature and store it in 'aggregates'
+   f = HTSeq.GenomicFeature( aggregate_id, "exonic_part", iv )
+   f.source = os.path.basename( sys.argv[0] )
+#   f.source = "camara"
+   f.attr = {}
+   f.attr[ 'gene_id' ] = aggregate_id
+   transcript_set = set( ( transcript_id for gene_id, transcript_id in s ) )
+   f.attr[ 'transcripts' ] = '+'.join( transcript_set )
+   aggregates[ aggregate_id ].append( f )
+
+
+# Step 4: For each aggregate, number the exonic parts
+
+aggregate_features = []
+for l in aggregates.values():
+   for i in range( len(l)-1 ):
+      assert l[i].name == l[i+1].name, str(l[i+1]) + " has wrong name"
+      assert l[i].iv.end <= l[i+1].iv.start, str(l[i+1]) + " starts too early"
+      if l[i].iv.chrom != l[i+1].iv.chrom:
+         raise ValueError(
+            "Same name found on two chromosomes: %s, %s" % ( str(l[i]), str(l[i+1]) )
+         )
+      if l[i].iv.strand != l[i+1].iv.strand:
+         raise ValueError(
+            "Same name found on two strands: %s, %s" % ( str(l[i]), str(l[i+1]) )
+         )
+   aggr_feat = HTSeq.GenomicFeature( l[0].name, "aggregate_gene",
+      HTSeq.GenomicInterval( l[0].iv.chrom, l[0].iv.start,
+         l[-1].iv.end, l[0].iv.strand ) )
+   aggr_feat.source = os.path.basename( sys.argv[0] )
+   aggr_feat.attr = { 'gene_id': aggr_feat.name }
+   for i in range( len(l) ):
+      l[i].attr['exonic_part_number'] = "%03d" % ( i+1 )
+   aggregate_features.append( aggr_feat )
+
+
+# Step 5: Sort the aggregates, then write everything out
+
+aggregate_features.sort( key = lambda f: ( f.iv.chrom, f.iv.start ) )
+
+fout = open( out_file, "w" )
+for aggr_feat in aggregate_features:
+   fout.write( aggr_feat.get_gff_line() )
+   for f in aggregates[ aggr_feat.name ]:
+      fout.write( f.get_gff_line() )
+
+fout.close()
+
+## modify file to print gtf if featurecounts gtf requested
+fcountgtf = opts.fcgtf
+
+if fcountgtf :
+	os.system('sed s/aggregate_gene/gene/g ' + out_file + ' > ' + fcountgtf)
+	os.system('sed -i s/exonic_part/exon/g ' + fcountgtf)
+	print("Done!")
+else :
+	print("Done!")

--- a/bin/run_dexseq_exon.R
+++ b/bin/run_dexseq_exon.R
@@ -146,19 +146,19 @@ reducedModel <- as.formula("~sample + exon")
 
 if (read_method == "htseq"){
 
-    dxd <- DEXSeq::DEXSeqDataSetFromHTSeq(countfiles = countFiles,
+  dxd <- DEXSeq::DEXSeqDataSetFromHTSeq(countfiles = countFiles,
                                         sampleData = samps,
                                         design = fullModel,
                                         flattenedfile = flattenedFile)
-}
+  }
 
 if (read_method == "featurecounts"){
 
-    dxd <- DEXSeqDataSetFromFeatureCounts(countfile = countFiles,
+  dxd <- DEXSeqDataSetFromFeatureCounts(countfile = countFiles,
                                         sampleData = samps,
-                                        design = fullModel,   
+                                        design = fullModel,
                                         flattenedfile = flattenedFile)
- }
+  }
 
 dxd <- DEXSeq::estimateSizeFactors(dxd)
 

--- a/bin/run_dexseq_exon.R
+++ b/bin/run_dexseq_exon.R
@@ -79,16 +79,16 @@ if (read_method == "htseq"){
                                         flattenedfile = flattenedFile)
 }
 
-# TODO Implement featurecounts input option
-# if (read_method == "featurecounts"){
+if (read_method == "featurecounts"){
 
-#     source("load_SubreadOutput.R")
+     source("load_SubreadOutput.R")
 
-#     dxd <- DEXSeqDataSetFromFeatureCounts(countFiles,
-#                                           flattenedfile = flattenedFile,
-#                                           sampleData = samps)
+     dxd <- DEXSeqDataSetFromFeatureCounts(countfiles = countFiles,
+                                           sampleData = samps,
+                                           design = fullModel,
+                                           flattenedfile = flattenedFile)
 
-# }
+ }
 
 dxd <- DEXSeq::estimateSizeFactors(dxd)
 

--- a/bin/run_dexseq_exon.R
+++ b/bin/run_dexseq_exon.R
@@ -2,6 +2,8 @@
 
 library(DEXSeq)
 library(BiocParallel)
+library(dplyr)
+library(purrr)
 
 args <- commandArgs(trailingOnly=TRUE)
 
@@ -23,7 +25,7 @@ samplesheet    <- args[3] # samplesheet
 read_method    <- args[4] # either HTSeq or featurecounts
 ncores         <- args[5] # MultiCoreParam ncores
 
-if (length(args) == 6) {
+if (length(args) == 7) {
 
     denominator <- args[6]  # denominator for lfc set by user
 
@@ -59,6 +61,79 @@ samps <- samps[,c("sample", "condition")]
 # filter for unique rows based on sample name
 samps <- samps[!duplicated(samps[,"sample"]),]
 
+#################################################
+######## Define featurescounts function #########
+#################################################
+
+## Load Fcount output from : DEXSeq_after_Fcount.R into DEXSeq
+## Copyright 2015 Vivek Bhardwaj (bhardwaj@ie-freiburg.mpg.de). Licence: GPLv3.
+
+suppressPackageStartupMessages({
+    require(DEXSeq)
+})
+
+## Read Fcount output and convert to dxd
+DEXSeqDataSetFromFeatureCounts <- function (countfile, sampleData,
+                                            design = ~sample + exon + condition:exon, flattenedfile = NULL)
+
+    {
+        # Take a fcount file and convert it to dcounts for dexseq
+        message("Reading and adding Exon IDs for DEXSeq")
+        for (file in countFiles){
+            if (!exists("dcounts")){
+                dcounts <- read.table(file, skip=2)
+            } else {
+                temp_dcounts <-read.table(file, skip=2)
+                dcounts<-merge(dcounts, temp_dcounts, by.x = "V1", by.y = "V1")
+                rm(temp_dcounts)
+            }
+        }
+        colnames(dcounts) <- c("GeneID", rownames(sampleData) )
+        rownames(dcounts) <- as.character(dcounts[,1])
+        dcounts <- dcounts[,2:ncol(dcounts)]
+        dcounts <- dcounts[substr(rownames(dcounts), 1, 1) != "_", ] #remove _ from beginnning of gene name
+
+        ## get genes and exon names out
+        splitted <- strsplit(rownames(dcounts), ":")
+        exons <- sapply(splitted, "[[", 2)
+        genesrle <- sapply(splitted, "[[", 1)
+
+        ## parse the flattened file
+        if (!is.null(flattenedfile)) {
+            aggregates <- read.delim(flattenedfile, stringsAsFactors = FALSE, header = FALSE)
+            colnames(aggregates) <- c("chr", "source", "class", "start", "end", "ex", "strand", "ex2", "attr")
+            aggregates$strand <- gsub("\\.", "*", aggregates$strand)
+            aggregates <- aggregates[which(aggregates$class == "exonic_part"), ]
+            aggregates$attr <- gsub("\"|=|;", "", aggregates$attr)
+            aggregates$gene_id <- sub(".*gene_id\\s(\\S+).*", "\\1", aggregates$attr)
+            # trim the gene_ids to 255 chars in order to match with featurecounts
+            longIDs <- sum(nchar(unique(aggregates$gene_id)) > 255)
+            warning(paste0(longIDs, " aggregate geneIDs were found truncated in featureCounts output"), call. = FALSE)
+            aggregates$gene_id <- substr(aggregates$gene_id,1,255)
+
+            transcripts <- gsub(".*transcripts\\s(\\S+).*", "\\1", aggregates$attr)
+            transcripts <- strsplit(transcripts, "\\+")
+            exonids <- gsub(".*exonic_part_number\\s(\\S+).*", "\\1", aggregates$attr)
+            exoninfo <- GRanges(as.character(aggregates$chr), IRanges(start = aggregates$start, end = aggregates$end), strand = aggregates$strand)
+            names(exoninfo) <- paste(aggregates$gene_id, exonids, sep = ":")
+
+            names(transcripts) <- names(exoninfo)
+            if (!all(rownames(dcounts) %in% names(exoninfo))) {
+                    stop("Count files do not correspond to the flattened annotation file")
+            }
+            matching <- match(rownames(dcounts), names(exoninfo))
+            stopifnot(all(names(exoninfo[matching]) == rownames(dcounts)))
+            stopifnot(all(names(transcripts[matching]) == rownames(dcounts)))
+            dxd <- DEXSeqDataSet(dcounts, sampleData, design, exons, genesrle, exoninfo[matching], transcripts[matching])
+            return(dxd)
+        }
+        else {
+            dxd <- DEXSeqDataSet(dcounts, sampleData, design, exons, genesrle)
+            return(dxd)
+        }
+
+}
+
 ######################################
 ######## Run DEXseq analysis #########
 ######################################
@@ -81,13 +156,10 @@ if (read_method == "htseq"){
 
 if (read_method == "featurecounts"){
 
-     source("load_SubreadOutput.R")
-
-     dxd <- DEXSeqDataSetFromFeatureCounts(countfiles = countFiles,
-                                           sampleData = samps,
-                                           design = fullModel,
-                                           flattenedfile = flattenedFile)
-
+    dxd <- DEXSeqDataSetFromFeatureCounts(countfile = countFiles,
+                                        sampleData = samps,
+                                        design = fullModel,   
+                                        flattenedfile = flattenedFile)
  }
 
 dxd <- DEXSeq::estimateSizeFactors(dxd)

--- a/bin/run_dexseq_exon.R
+++ b/bin/run_dexseq_exon.R
@@ -146,19 +146,19 @@ reducedModel <- as.formula("~sample + exon")
 
 if (read_method == "htseq"){
 
-  dxd <- DEXSeq::DEXSeqDataSetFromHTSeq(countfiles = countFiles,
+    dxd <- DEXSeq::DEXSeqDataSetFromHTSeq(countfiles = countFiles,
                                         sampleData = samps,
                                         design = fullModel,
                                         flattenedfile = flattenedFile)
-  }
+}
 
 if (read_method == "featurecounts"){
 
-  dxd <- DEXSeqDataSetFromFeatureCounts(countfile = countFiles,
+    dxd <- DEXSeqDataSetFromFeatureCounts(countfile = countFiles,
                                         sampleData = samps,
                                         design = fullModel,
                                         flattenedfile = flattenedFile)
-  }
+}
 
 dxd <- DEXSeq::estimateSizeFactors(dxd)
 

--- a/bin/run_dexseq_exon.R
+++ b/bin/run_dexseq_exon.R
@@ -2,8 +2,6 @@
 
 library(DEXSeq)
 library(BiocParallel)
-library(dplyr)
-library(purrr)
 
 args <- commandArgs(trailingOnly=TRUE)
 
@@ -25,7 +23,7 @@ samplesheet    <- args[3] # samplesheet
 read_method    <- args[4] # either HTSeq or featurecounts
 ncores         <- args[5] # MultiCoreParam ncores
 
-if (length(args) == 7) {
+if (length(args) == 6) {
 
     denominator <- args[6]  # denominator for lfc set by user
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -350,7 +350,7 @@ if (params.dexseq_exon) {
 
         withName: 'DEXSEQ_EXON' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/dexseq_exon/results" },
+                path: { "${params.outdir}/${params.aligner}/dexseq_exon/results/${params.dexseq_read_method}" },
                 mode: params.publish_dir_mode,
                 pattern: "*.{tsv,rds}",
             ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -336,21 +336,36 @@ if (params.dexseq_exon) {
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/dexseq_exon/annotation" },
                 mode: params.publish_dir_mode,
-                pattern: "*.gff"
+                pattern: "*.{gff, gtf}"
             ]
         }
 
         withName: 'DEXSEQ_COUNT' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/dexseq_exon/counts" },
+                path: { "${params.outdir}/${params.aligner}/dexseq_exon/${params.dexseq_read_method}/counts" },
                 mode: params.publish_dir_mode,
                 pattern: "*.clean.count.txt",
             ]
         }
 
+        withName: 'SUBREAD_FEATURECOUNTS_DEXSEQ' {
+            ext.args   = [
+                '-f',
+                '-O',
+                '-p',
+                '-F GTF'
+            ].join(' ').trim()
+            publishDir = [
+                path: { "${params.outdir}/${params.aligner}/dexseq_exon/${params.dexseq_read_method}/counts" },
+                mode: params.publish_dir_mode,
+                pattern: "*.txt",
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            ]
+        }
+
         withName: 'DEXSEQ_EXON' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/dexseq_exon/results/${params.dexseq_read_method}" },
+                path: { "${params.outdir}/${params.aligner}/dexseq_exon/${params.dexseq_read_method}/results" },
                 mode: params.publish_dir_mode,
                 pattern: "*.{tsv,rds}",
             ]
@@ -435,7 +450,7 @@ if (params.pseudo_aligner == "salmon" && params.dexseq_dtu) {
 
 if (params.edger_exon) {
     process {
-        withName: 'SUBREAD_FEATURECOUNTS' {
+        withName: 'SUBREAD_FEATURECOUNTS_EDGER' {
             ext.args   = [
                 '-F GTF',
                 "-t exon",
@@ -446,7 +461,7 @@ if (params.edger_exon) {
                 '-C'
             ].join(' ').trim()
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/featurecounts" },
+                path: { "${params.outdir}/${params.aligner}/edger/featurecounts" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -455,7 +470,7 @@ if (params.edger_exon) {
     process {
         withName: 'EDGER_EXON' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/edger" },
+                path: { "${params.outdir}/${params.aligner}/edger/results" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]

--- a/lib/WorkflowRnasplice.groovy
+++ b/lib/WorkflowRnasplice.groovy
@@ -82,6 +82,13 @@ class WorkflowRnasplice {
             }
         }
 
+        if (!params.skip_alignment && params.dexseq_exon) {
+            if (!valid_params['dexseq_read_methods'].contains(params.dexseq_read_method)) {
+                log.error "Invalid option: '${params.dexseq_read_method}'. Valid options for '--dexseq_read_method': ${valid_params['dexseq_read_methods'].join(', ')}."
+                System.exit(1)
+            }
+        }
+
         //
         // TODO: Include star_rsem code for future release.
         //

--- a/modules/local/dexseq_annotation.nf
+++ b/modules/local/dexseq_annotation.nf
@@ -11,8 +11,9 @@ process DEXSEQ_ANNOTATION {
     path gtf
 
     output:
-    path "*.gff"        , emit: gff
-    path "versions.yml" , emit: versions
+    path "*.gff"                , emit: gff
+    path "featurecounts.gtf"    , emit: featurecounts_gtf
+    path "versions.yml"         , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,7 +26,7 @@ process DEXSEQ_ANNOTATION {
     def aggregation = params.aggregation ? '' : '-r no'
 
     """
-    dexseq_prepare_annotation.py $gtf ${prefix}.gff $aggregation
+    dexseq_prepare_annotation2.py -f featurecounts.gtf $gtf ${prefix}.gff $aggregation
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/dexseq_exon.nf
+++ b/modules/local/dexseq_exon.nf
@@ -9,6 +9,7 @@ process DEXSEQ_EXON {
     input:
     path ("dexseq_clean_counts/*")     // path dexseq_clean_counts
     path gff                           // path dexseq_gff
+    path gtf                           // path featurecounts_gtf
     path samplesheet                   // path samplesheet
     val read_method                    // htseq or featurecounts
 
@@ -24,7 +25,7 @@ process DEXSEQ_EXON {
     def denominator = params.deu_lfc_denominator ?: ""
 
     """
-    run_dexseq_exon.R dexseq_clean_counts $gff $samplesheet $read_method ${task.cpus} $denominator
+    run_dexseq_exon.R dexseq_clean_counts $gff $gtf $samplesheet $read_method ${task.cpus} $denominator
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,6 +61,7 @@ params {
     // DEXSeq DEU
     dexseq_exon                = false
     gff_dexseq                 = null
+    dexseq_read_method         = 'htseq' // htseq or featurecounts
     alignment_quality          = 10
     aggregation                = true
     deu_lfc_denominator        = "GBR"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -485,6 +485,10 @@
                     "type": "string",
                     "default": "None"
                 },
+                "dexseq_read_method": {
+                    "type": "string",
+                    "default": "htseq"
+                },
                 "alignment_quality": {
                     "type": "integer",
                     "default": 10

--- a/subworkflows/local/dexseq_deu.nf
+++ b/subworkflows/local/dexseq_deu.nf
@@ -3,6 +3,7 @@
 //
 include { DEXSEQ_ANNOTATION   } from '../../modules/local/dexseq_annotation'
 include { DEXSEQ_COUNT        } from '../../modules/local/dexseq_count'
+include { SUBREAD_FEATURECOUNTS  as SUBREAD_FEATURECOUNTS_DEXSEQ  } from '../../modules/nf-core/subread/featurecounts'
 include { DEXSEQ_EXON         } from '../../modules/local/dexseq_exon'
 
 workflow DEXSEQ_DEU {
@@ -34,28 +35,47 @@ workflow DEXSEQ_DEU {
         ch_versions = ch_versions.mix(DEXSEQ_ANNOTATION.out.versions.first())
 
         ch_dexseq_gff = DEXSEQ_ANNOTATION.out.gff
-
+        ch_featurecounts_gtf = ch_genome_bam.combine(DEXSEQ_ANNOTATION.out.featurecounts_gtf)
     }
 
     ch_genome_bam_gff = ch_genome_bam.combine(ch_dexseq_gff)
 
-    //
-    // MODULE: DEXSeq Count
-    //
+    ch_counts = Channel.empty()
 
-    DEXSEQ_COUNT (
-        ch_genome_bam_gff
-    )
+    if (read_method == 'htseq')  {
+        //
+        // MODULE: DEXSeq Count
+        //
 
-    ch_versions = ch_versions.mix(DEXSEQ_COUNT.out.versions.first())
+        DEXSEQ_COUNT (
+            ch_genome_bam_gff
+        )
+
+        ch_versions = ch_versions.mix(DEXSEQ_COUNT.out.versions.first())
+        dexseq_clean_txt = DEXSEQ_COUNT.out.dexseq_clean_txt.collect()
+    }
+
+    if (read_method == 'featurecounts')  {
+        //
+        // MODULE: SUBREAD_FEATURECOUNTS_DEXSEQ
+        //
+
+         SUBREAD_FEATURECOUNTS_DEXSEQ (
+            ch_featurecounts_gtf
+        )
+
+        ch_versions = ch_versions.mix(SUBREAD_FEATURECOUNTS_DEXSEQ.out.versions.first())
+        dexseq_clean_txt = SUBREAD_FEATURECOUNTS_DEXSEQ.out.counts.collect({it[1]})
+    }
 
     //
     // MODULE: DEXSeq differential exon usage
     //
 
     DEXSEQ_EXON (
-        DEXSEQ_COUNT.out.dexseq_clean_txt.collect(),
+        dexseq_clean_txt,
         ch_dexseq_gff,
+        DEXSEQ_ANNOTATION.out.featurecounts_gtf,
         ch_samplesheet,
         read_method
     )
@@ -64,8 +84,7 @@ workflow DEXSEQ_DEU {
 
     emit:
 
-    dexseq_clean_txt           = DEXSEQ_COUNT.out.dexseq_clean_txt.collect()
-
+    dexseq_clean_txt
     dexseq_exon_rds            = DEXSEQ_EXON.out.dexseq_exon_rds              // path: dxd.rds
     dexseq_exon_results_rds    = DEXSEQ_EXON.out.dexseq_exon_results_rds      // path: dxr.rds
     dexseq_exon_results_tsv    = DEXSEQ_EXON.out.dexseq_exon_results_tsv      // path: dxr.tsv

--- a/subworkflows/local/edger_deu.nf
+++ b/subworkflows/local/edger_deu.nf
@@ -2,7 +2,7 @@
 // edgeR DEU subworkflow
 //
 
-include { SUBREAD_FEATURECOUNTS } from '../../modules/nf-core/subread/featurecounts/main'
+include { SUBREAD_FEATURECOUNTS as SUBREAD_FEATURECOUNTS_EDGER } from '../../modules/nf-core/subread/featurecounts/main'
 include { EDGER_EXON            } from '../../modules/local/edger_exon'
 
 workflow EDGER_DEU {
@@ -18,30 +18,28 @@ workflow EDGER_DEU {
     ch_versions = Channel.empty()
 
     //
-    // MODULE: SUBREAD_FEATURECOUNTS
+    // MODULE: EDGER_SUBREAD_FEATURECOUNTS
     //
 
     ch_feature_counts = ch_genome_bam.combine(gtf)
 
-    SUBREAD_FEATURECOUNTS(ch_feature_counts)
-
-    ch_versions = ch_versions.mix(SUBREAD_FEATURECOUNTS.out.versions.first())
-
-    //
-    // MODULE: EDGER_COUNTS
-    //
-    EDGER_EXON (
-        SUBREAD_FEATURECOUNTS.out.counts.collect({it[1]}),
-        ch_samplesheet
+    SUBREAD_FEATURECOUNTS_EDGER(
+        ch_feature_counts
     )
+
+    ch_versions = ch_versions.mix(SUBREAD_FEATURECOUNTS_EDGER.out.versions.first())
 
     //
     // MODULE: EDGER_EXON
     //
+    EDGER_EXON (
+        SUBREAD_FEATURECOUNTS_EDGER.out.counts.collect({it[1]}),
+        ch_samplesheet
+    )
 
     emit:
 
-    featureCounts_summary  = SUBREAD_FEATURECOUNTS.out.summary  // path featureCounts.txt.summary
+    featureCounts_summary  = SUBREAD_FEATURECOUNTS_EDGER.out.summary            // path featureCounts.txt.summary
 
     versions               = ch_versions                        // channel: [ versions.yml ]
 

--- a/workflows/rnasplice.nf
+++ b/workflows/rnasplice.nf
@@ -6,7 +6,8 @@
 
 def valid_params = [
     aligners       : ['star', 'star_salmon'],
-    pseudoaligners : ['salmon']
+    pseudoaligners : ['salmon'],
+    dexseq_read_methods : ['htseq', 'featurecounts']
 ]
 
 def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)

--- a/workflows/rnasplice.nf
+++ b/workflows/rnasplice.nf
@@ -254,14 +254,13 @@ workflow RNASPLICE {
         if (params.dexseq_exon) {
 
             ch_dexseq_gff = params.gff_dexseq ? PREPARE_GENOME.out.dexseq_gff : ""
-            def read_method = "htseq"
 
             DEXSEQ_DEU(
                 PREPARE_GENOME.out.gtf,
                 ch_genome_bam,
                 ch_dexseq_gff,
                 ch_samplesheet,
-                read_method
+                params.dexseq_read_method
             )
 
             ch_versions = ch_versions.mix(DEXSEQ_DEU.out.versions)


### PR DESCRIPTION
Hi,

There is currently no option to use the `featurecounts` read method for DEXSeq DEU, with the only option currently being `htseq`. This PR has included a function (adapted from the load_SubreadOutput.R script) to use this method in the run_dexseq_exon.R script. In addition, this PR updates the relevant config files to include this method option. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
