### PR TITLE
SL-18 Update SAMTOOLS_INDEX publishDir pattern

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -286,7 +286,7 @@ if (!params.skip_alignment) {
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}" },
                 mode: params.publish_dir_mode,
-                pattern: "*.{bam,csi}",
+                pattern: "*.{bai,csi}",
                 enabled: ( ['star_salmon','star'].contains(params.aligner))
             ]
         }


### PR DESCRIPTION
Hi,

Currently the file ext. pattern for the SAMTOOLS_INDEX module has been misspecified as bam, csi in the modules.config file. This PR modifies this to bai,csi ensuring the outputs are correctly saved. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
