### PR TITLE
remove sniffer

### DIFF
--- a/bin/check_contrastsheet.py
+++ b/bin/check_contrastsheet.py
@@ -99,29 +99,29 @@ def read_head(handle, num_lines=10):
     return "".join(lines)
 
 
-def sniff_format(handle):
-    """
-    Detect the tabular format.
+# def sniff_format(handle):
+#     """
+#     Detect the tabular format.
 
-    Args:
-        handle (text file): A handle to a `text file`_ object. The read position is
-        expected to be at the beginning (index 0).
+#     Args:
+#         handle (text file): A handle to a `text file`_ object. The read position is
+#         expected to be at the beginning (index 0).
 
-    Returns:
-        csv.Dialect: The detected tabular format.
+#     Returns:
+#         csv.Dialect: The detected tabular format.
 
-    .. _text file:
-        https://docs.python.org/3/glossary.html#term-text-file
+#     .. _text file:
+#         https://docs.python.org/3/glossary.html#term-text-file
 
-    """
-    peek = read_head(handle)
-    handle.seek(0)
-    sniffer = csv.Sniffer()
-    if not sniffer.has_header(peek):
-        logger.critical("The given contrast sheet does not appear to contain a header.")
-        sys.exit(1)
-    dialect = sniffer.sniff(peek)
-    return dialect
+#     """
+#     peek = read_head(handle)
+#     handle.seek(0)
+#     sniffer = csv.Sniffer()
+#     if not sniffer.has_header(peek):
+#         logger.critical("The given contrast sheet does not appear to contain a header.")
+#         sys.exit(1)
+#     dialect = sniffer.sniff(peek)
+#     return dialect
 
 
 def check_contrastsheet(file_in, file_out):
@@ -148,7 +148,7 @@ def check_contrastsheet(file_in, file_out):
     required_columns = {"contrast", "treatment", "control"}
     # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
     with file_in.open(newline="") as in_handle:
-        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
+        reader = csv.DictReader(in_handle)
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
             req_cols = ", ".join(required_columns)
@@ -182,7 +182,7 @@ def parse_args(argv=None):
         "file_in",
         metavar="FILE_IN",
         type=Path,
-        help="Tabular input contrastsheet in CSV or TSV format.",
+        help="Tabular input contrastsheet in CSV format.",
     )
     parser.add_argument(
         "file_out",

--- a/bin/check_samplesheet_fastq.py
+++ b/bin/check_samplesheet_fastq.py
@@ -172,26 +172,26 @@ def read_head(handle, num_lines=10):
     return "".join(lines)
 
 
-def sniff_format(handle):
-    """
-    Detect the tabular format.
+# def sniff_format(handle):
+#     """
+#     Detect the tabular format.
 
-    Args:
-        handle (text file): A handle to a `text file`_ object. The read position is
-        expected to be at the beginning (index 0).
+#     Args:
+#         handle (text file): A handle to a `text file`_ object. The read position is
+#         expected to be at the beginning (index 0).
 
-    Returns:
-        csv.Dialect: The detected tabular format.
+#     Returns:
+#         csv.Dialect: The detected tabular format.
 
-    .. _text file:
-        https://docs.python.org/3/glossary.html#term-text-file
+#     .. _text file:
+#         https://docs.python.org/3/glossary.html#term-text-file
 
-    """
-    peek = read_head(handle)
-    handle.seek(0)
-    sniffer = csv.Sniffer()
-    dialect = sniffer.sniff(peek)
-    return dialect
+#     """
+#     peek = read_head(handle)
+#     handle.seek(0)
+#     sniffer = csv.Sniffer()
+#     dialect = sniffer.sniff(peek)
+#     return dialect
 
 
 def check_condition_replicates(samplesheet):
@@ -237,7 +237,7 @@ def check_samplesheet(file_in, file_out):
     required_columns = {"sample", "fastq_1", "fastq_2", "strandedness", "condition"}
     # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
     with file_in.open(newline="") as in_handle:
-        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
+        reader = csv.DictReader(in_handle)
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
             req_cols = ", ".join(required_columns)

--- a/bin/check_samplesheet_genome_bam.py
+++ b/bin/check_samplesheet_genome_bam.py
@@ -126,29 +126,29 @@ def read_head(handle, num_lines=10):
     return "".join(lines)
 
 
-def sniff_format(handle):
-    """
-    Detect the tabular format.
+# def sniff_format(handle):
+#     """
+#     Detect the tabular format.
 
-    Args:
-        handle (text file): A handle to a `text file`_ object. The read position is
-        expected to be at the beginning (index 0).
+#     Args:
+#         handle (text file): A handle to a `text file`_ object. The read position is
+#         expected to be at the beginning (index 0).
 
-    Returns:
-        csv.Dialect: The detected tabular format.
+#     Returns:
+#         csv.Dialect: The detected tabular format.
 
-    .. _text file:
-        https://docs.python.org/3/glossary.html#term-text-file
+#     .. _text file:
+#         https://docs.python.org/3/glossary.html#term-text-file
 
-    """
-    peek = read_head(handle)
-    handle.seek(0)
-    sniffer = csv.Sniffer()
-    if not sniffer.has_header(peek):
-        logger.critical("The given sample sheet does not appear to contain a header.")
-        sys.exit(1)
-    dialect = sniffer.sniff(peek)
-    return dialect
+#     """
+#     peek = read_head(handle)
+#     handle.seek(0)
+#     sniffer = csv.Sniffer()
+#     if not sniffer.has_header(peek):
+#         logger.critical("The given sample sheet does not appear to contain a header.")
+#         sys.exit(1)
+#     dialect = sniffer.sniff(peek)
+#     return dialect
 
 
 def check_condition_replicates(samplesheet):
@@ -194,7 +194,7 @@ def check_samplesheet(file_in, file_out):
     required_columns = {"sample", "genome_bam", "condition"}
     # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
     with file_in.open(newline="") as in_handle:
-        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
+        reader = csv.DictReader(in_handle)
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
             req_cols = ", ".join(required_columns)

--- a/bin/check_samplesheet_salmon_results.py
+++ b/bin/check_samplesheet_salmon_results.py
@@ -128,29 +128,29 @@ def read_head(handle, num_lines=10):
     return "".join(lines)
 
 
-def sniff_format(handle):
-    """
-    Detect the tabular format.
+# def sniff_format(handle):
+#     """
+#     Detect the tabular format.
 
-    Args:
-        handle (text file): A handle to a `text file`_ object. The read position is
-        expected to be at the beginning (index 0).
+#     Args:
+#         handle (text file): A handle to a `text file`_ object. The read position is
+#         expected to be at the beginning (index 0).
 
-    Returns:
-        csv.Dialect: The detected tabular format.
+#     Returns:
+#         csv.Dialect: The detected tabular format.
 
-    .. _text file:
-        https://docs.python.org/3/glossary.html#term-text-file
+#     .. _text file:
+#         https://docs.python.org/3/glossary.html#term-text-file
 
-    """
-    peek = read_head(handle)
-    handle.seek(0)
-    sniffer = csv.Sniffer()
-    if not sniffer.has_header(peek):
-        logger.critical("The given sample sheet does not appear to contain a header.")
-        sys.exit(1)
-    dialect = sniffer.sniff(peek)
-    return dialect
+#     """
+#     peek = read_head(handle)
+#     handle.seek(0)
+#     sniffer = csv.Sniffer()
+#     if not sniffer.has_header(peek):
+#         logger.critical("The given sample sheet does not appear to contain a header.")
+#         sys.exit(1)
+#     dialect = sniffer.sniff(peek)
+#     return dialect
 
 
 def check_condition_replicates(samplesheet):
@@ -196,7 +196,7 @@ def check_samplesheet(file_in, file_out):
     required_columns = {"sample", "salmon_results", "condition"}
     # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
     with file_in.open(newline="") as in_handle:
-        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
+        reader = csv.DictReader(in_handle)
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
             req_cols = ", ".join(required_columns)

--- a/bin/check_samplesheet_transcriptome_bam.py
+++ b/bin/check_samplesheet_transcriptome_bam.py
@@ -126,29 +126,29 @@ def read_head(handle, num_lines=10):
     return "".join(lines)
 
 
-def sniff_format(handle):
-    """
-    Detect the tabular format.
+# def sniff_format(handle):
+#     """
+#     Detect the tabular format.
 
-    Args:
-        handle (text file): A handle to a `text file`_ object. The read position is
-        expected to be at the beginning (index 0).
+#     Args:
+#         handle (text file): A handle to a `text file`_ object. The read position is
+#         expected to be at the beginning (index 0).
 
-    Returns:
-        csv.Dialect: The detected tabular format.
+#     Returns:
+#         csv.Dialect: The detected tabular format.
 
-    .. _text file:
-        https://docs.python.org/3/glossary.html#term-text-file
+#     .. _text file:
+#         https://docs.python.org/3/glossary.html#term-text-file
 
-    """
-    peek = read_head(handle)
-    handle.seek(0)
-    sniffer = csv.Sniffer()
-    if not sniffer.has_header(peek):
-        logger.critical("The given sample sheet does not appear to contain a header.")
-        sys.exit(1)
-    dialect = sniffer.sniff(peek)
-    return dialect
+#     """
+#     peek = read_head(handle)
+#     handle.seek(0)
+#     sniffer = csv.Sniffer()
+#     if not sniffer.has_header(peek):
+#         logger.critical("The given sample sheet does not appear to contain a header.")
+#         sys.exit(1)
+#     dialect = sniffer.sniff(peek)
+#     return dialect
 
 
 def check_condition_replicates(samplesheet):
@@ -194,7 +194,7 @@ def check_samplesheet(file_in, file_out):
     required_columns = {"sample", "transcriptome_bam", "condition"}
     # See https://docs.python.org/3.9/library/csv.html#id3 to read up on `newline=""`.
     with file_in.open(newline="") as in_handle:
-        reader = csv.DictReader(in_handle, dialect=sniff_format(in_handle))
+        reader = csv.DictReader(in_handle)
         # Validate the existence of the expected header columns.
         if not required_columns.issubset(reader.fieldnames):
             req_cols = ", ".join(required_columns)


### PR DESCRIPTION
This PR resolves issue #63 by removing the file format sniffer. The documentation requires users to specify a CSV file format, so there is no need to use the sniffer.