### PR TITLE
Remove default value from miso_genes_file to prevent checking for false file

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -659,7 +659,6 @@
                 },
                 "miso_genes_file": {
                     "type": "string",
-                    "default": "None",
                     "description": "New-line separate file containing identifiers of genes to plot."
                 },
                 "miso_read_len": {


### PR DESCRIPTION
The default for miso_genes_file was set to `None`, a Python value. It should have been null or blank. This PR removes it.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
