### PR TITLE
fix error when only one cluster is found in SUPPA CLUSTEREVENTS

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v2
+        with:
+          version: "24.04.2"
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
@@ -80,4 +82,4 @@ jobs:
           path: |
             lint_log.txt
             lint_results.md
-            PR_number.txt
+          PR_number.txt

--- a/modules/local/suppa_clusterevents.nf
+++ b/modules/local/suppa_clusterevents.nf
@@ -35,6 +35,8 @@ process CLUSTEREVENTS {
     def clusterevents_separation = clusterevents_separation ? "-s ${params.clusterevents_separation}" : ''
 
     """
+    touch ${cond1}-${cond2}_${prefix}_cluster
+
     suppa.py \\
         clusterEvents \\
         --dpsi $dpsi \\


### PR DESCRIPTION
<!--
# nf-core/rnasplice pull request

Many thanks for contributing to nf-core/rnasplice!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Fixes #187 

The expected output `${cond1}-${cond2}_${prefix}_cluster` is always created.