### PR TITLE
Pass the contrasts as expected instead of contrasts sheet to RMATS and SUPPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `SUBREAD_FLATTENGTF` multi-line version output breaking YAML parsing
 - Fixed `STAR_ALIGN` deprecated `--quantTranscriptomeBan` parameter renamed to `--quantTranscriptomeSAMoutput`
 - Fixed ignored arguments `--clip_r1` and `--clip_r2` in `TRIMGALORE` module for NextSeq trimming and read clipping
+- Pass the correct contrasts channel instead of the samplesheet channel `RMATS` and `SUPPA`
 
 ## v1.0.5 - 2024-11-03
 

--- a/subworkflows/local/rmats/main.nf
+++ b/subworkflows/local/rmats/main.nf
@@ -8,7 +8,7 @@ include { RMATS_POST     } from '../../../modules/local/rmats_post'
 
 workflow RMATS {
     take:
-    ch_contrasts // channel: contrastsheet
+    ch_contrasts // channel: contrasts = [ contrast, treatment, control ]
     ch_genome_bam_conditions // channel: genome_bam_conditions
     gtf // channel: /path/to/genome.gtf
     is_single_condition // channel: true/false

--- a/subworkflows/local/suppa/main.nf
+++ b/subworkflows/local/suppa/main.nf
@@ -28,7 +28,7 @@ workflow SUPPA {
     ch_gtf
     ch_tpm
     ch_samplesheet
-    ch_contrastsheet
+    ch_contrasts
     suppa_per_local_event       // params.suppa_per_local_event
     generateevents_boundary     // params.generateevents_boundary
     generateevents_threshold    // params.generateevents_threshold
@@ -138,7 +138,7 @@ workflow SUPPA {
 
             // Create contrasts channel
 
-            ch_suppa_local_contrasts_raw = ch_contrastsheet
+            ch_suppa_local_contrasts_raw = ch_contrasts
 
             // Add TPM files to contrasts channel
 
@@ -291,7 +291,7 @@ workflow SUPPA {
 
             // Create contrasts channel
 
-            ch_suppa_isoform_contrasts_raw = ch_contrastsheet
+            ch_suppa_isoform_contrasts_raw = ch_contrasts
 
             // Add TPM files to contrasts channel
 

--- a/workflows/rnasplice.nf
+++ b/workflows/rnasplice.nf
@@ -306,7 +306,7 @@ workflow RNASPLICE {
             def condition_idx = headers.indexOf('condition')
             def is_single_condition = lines[1..-1].collect { it -> it.split(',')[condition_idx].trim() }.unique().size() == 1
             RMATS(
-                ch_contrastsheet,
+                ch_contrasts,
                 ch_genome_bam_conditions,
                 ch_gtf,
                 is_single_condition,
@@ -380,7 +380,7 @@ workflow RNASPLICE {
                 ch_gtf,
                 ch_suppa_tpm,
                 ch_samplesheet,
-                ch_contrastsheet,
+                ch_contrasts,
                 params.suppa_per_local_event,
                 params.generateevents_boundary,
                 params.generateevents_threshold,
@@ -455,7 +455,7 @@ workflow RNASPLICE {
                 ch_gtf,
                 ch_suppa_tpm,
                 ch_samplesheet,
-                ch_contrastsheet,
+                ch_contrasts,
                 params.suppa_per_local_event,
                 params.generateevents_boundary,
                 params.generateevents_threshold,


### PR DESCRIPTION


<!--
# nf-core/rnasplice pull request

Many thanks for contributing to nf-core/rnasplice!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).

Fixes the arguments for RMATS and SUPPA which expect the contrasts map instead of the constrats sheet file channel.