### PR TITLE
pass number of cores to dexseq exon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `MISO_RUN` module into `MISOPY_RUN` to match nf-core module template.
 - Removed `parse_miso_index.py` script, as it is not necessary for misopy to work.
 - Refactored `SUBREAD_FLATTENGTF` to match nf-core module template.
+- Now `DEXSEQ_DTU` module uses `BPPARAM` argument to enable parallel processing, if no `BPPARAM` is provided, it defaults to `SerialParam()`.
 
 ### Fixed
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -762,7 +762,7 @@ process {
     }
 
     // --- MISO / Sashimi Plots ---
-    withName: 'GFFREAD_GTF2GFF3' {
+    withName: 'GTF_2_GFF3' {
         publishDir = [
             path: { "${params.outdir}/misopy" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -433,8 +433,6 @@ process {
     }
 
     withName: 'DEXSEQ_EXON' {
-        cpus = { Math.max(1, (16 / task.attempt) as int) }
-
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/dexseq_exon/results" },
             mode: params.publish_dir_mode,
@@ -764,7 +762,7 @@ process {
     }
 
     // --- MISO / Sashimi Plots ---
-    withName: 'GTF_2_GFF3' {
+    withName: 'GFFREAD_GTF2GFF3' {
         publishDir = [
             path: { "${params.outdir}/misopy" },
             mode: params.publish_dir_mode,

--- a/modules/local/dexseq/count/tests/main.nf.test.snap
+++ b/modules/local/dexseq/count/tests/main.nf.test.snap
@@ -27,6 +27,62 @@
             "nextflow": "26.04.3"
         }
     },
+    "single bam - stub": {
+        "content": [
+            {
+                "dexseq_clean_txt": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "unstranded",
+                            "single_end": true
+                        },
+                        "test.clean.count.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_htseq": [
+                    [
+                        "DEXSEQ_COUNT",
+                        "htseq",
+                        "2.1.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T12:30:34.068898906",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "single bam": {
+        "content": [
+            {
+                "dexseq_clean_txt": [
+                    [
+                        {
+                            "id": "test",
+                            "strandedness": "unstranded",
+                            "single_end": true
+                        },
+                        "test.clean.count.txt:md5,3d298b32dfc0a8eafb6870d9fdf74bb5"
+                    ]
+                ],
+                "versions_htseq": [
+                    [
+                        "DEXSEQ_COUNT",
+                        "htseq",
+                        "2.1.2"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-02T12:30:22.711886495",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
     "ERR188383": {
         "content": [
             {

--- a/modules/local/dexseq/exon/main.nf
+++ b/modules/local/dexseq/exon/main.nf
@@ -28,7 +28,7 @@ process DEXSEQ_EXON {
 
     script:
     """
-    run_dexseq_exon.R dexseq_clean_counts $gff $samplesheet $contrastsheet $ntop
+    run_dexseq_exon.R dexseq_clean_counts $gff $samplesheet $contrastsheet $ntop ${task.cpus}
     """
 
     stub:


### PR DESCRIPTION
<!--
# nf-core/rnasplice pull request

Many thanks for contributing to nf-core/rnasplice!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Now DEXSEQ_DTU passes the number of cores for BBPARAM and revert to Serial when 1 is passed.