### PR TITLE
Fix missing backslash in stub code of clustergroups module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #219 - Fixed `MISOPY` module to correctly handle paired-end reads and pass the correct BAM files to MISOPY (by @piplus2)
 - #224 - Fixed `DEXSEQ_DTU` script to correctly handle the sample IDs (reported by @albamasmalavila, fix by @piplus2)
 - #232 - Fixed wrong branch when input is BAM in `dev` (reported by @albamasmalavila, fix by @piplus2)
-- #238 - missing backslash in `mergeevents` command in `dev` branch (by @piplus2)
+- #238 - Added missing backslash in `mergeevents` command in `dev` branch (by @piplus2)
+- #241 - Added missing backslash in `clusterevents` command in `dev` branch (by @piplus2)
 
 ## v1.0.5 - 2024-11-03
 

--- a/modules/local/clustergroups/main.nf
+++ b/modules/local/clustergroups/main.nf
@@ -30,7 +30,7 @@ process CLUSTERGROUPS {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        suppa_groups: "$(python3 --version 2>&1 | sed -n '1p' | sed 's/.*version //; s/ (.*//')"
+        suppa_groups: "\$(python3 --version 2>&1 | sed -n '1p' | sed 's/.*version //; s/ (.*//')"
     END_VERSIONS
     """
 }


### PR DESCRIPTION
<!--
# nf-core/rnasplice pull request

Many thanks for contributing to nf-core/rnasplice!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnasplice/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnasplice _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Fix #240 missing backslash in clustergroups module