### PR TITLE
Port align_star subworkflow to the nf-core structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #253 - Sync pipeline with nf-core template 4.1.0-2 (by @piplus2)
 - #254 - Moved the local `GTF_GENE_FILTER` module to `modules/local/gtfgenefilter` as `GTFGENEFILTER` to match the nf-core module template, adding `environment.yml`, `meta.yml`, a stub section and an nf-test. The bundled `bin/filter_gtf_for_genes_in_genome.py` script is now a module template (by @piplus2)
 - #255 - Moved the local `EDGER_EXON` module to `modules/local/edger/exon` to match the nf-core module template, adding `environment.yml`, `meta.yml`, a stub section and an nf-test. The bundled `bin/run_edger_exon.R` script is now a module template, `--n_edger_plot` is passed through `ext.args` instead of a process input and the module inputs and outputs now carry a `meta` map as in the nf-core modules (by @piplus2)
+- #256 - Moved the local `ALIGN_STAR` subworkflow to the nf-core subworkflow template, adding `meta.yml` and nf-tests covering both the `STAR_ALIGN` and the `STAR_ALIGN_IGENOMES` paths. `STAR_ALIGN_IGENOMES` and `STAR_GENOMEGENERATE_IGENOMES` gained stub sections (by @piplus2)
 
 ### Fixed
 
@@ -76,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #245 - Fixed ignored `--tximport_ignore_tx_version` argument in `TXIMPORT` module (by @piplus2)
 - #254 - Fixed `GTFGENEFILTER` logging the characters of the last GTF sequence name instead of the set of sequence names found in the GTF, which also raised a `NameError` on an empty GTF. The module now fails with an explicit error when no GTF feature matches a sequence in the genome FASTA (by @piplus2)
 - #255 - Fixed `EDGER_EXON` writing an unreadable zero-page PDF when a contrast has no gene to plot. The module now also fails with an explicit error when the samplesheet or the contrastsheet miss a required column, when a sample is assigned to more than one condition, when a condition of the contrastsheet is absent from the samplesheet or when a featureCounts table is missing (by @piplus2)
+- #256 - Fixed the software version `eval` commands of `STAR_ALIGN_IGENOMES` and `STAR_GENOMEGENERATE_IGENOMES`, which failed with a shell syntax error and aborted both processes (by @piplus2)
+- #256 - Fixed the iGenomes STAR alignment path: `STAR_ALIGN_IGENOMES` pins STAR 2.6.1d, which does not accept `--quantTranscriptomeSAMoutput`, so it now uses the equivalent `--quantTranscriptomeBan Singleend` (by @piplus2)
 
 ## v1.0.5 - 2024-11-03
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -239,6 +239,23 @@ process {
         ]
     }
 
+    // `STAR_ALIGN_IGENOMES` pins STAR 2.6.1d, which predates `--quantTranscriptomeSAMoutput`.
+    // Use the equivalent legacy option so the iGenomes path accepts the arguments above.
+    withName: 'STAR_ALIGN_IGENOMES' {
+        ext.args   = { [
+            '--quantMode TranscriptomeSAM',
+            '--twopassMode Basic',
+            '--outSAMtype BAM Unsorted',
+            '--readFilesCommand gunzip -c',
+            '--runRNGseed 0',
+            '--outFilterMultimapNmax 20',
+            '--alignSJDBoverhangMin 1',
+            '--outSAMattributes NH HI AS NM MD',
+            '--quantTranscriptomeBan Singleend',
+            params.save_unaligned ? '--outReadsUnmapped Fastx' : ''
+        ].join(' ').trim() }
+    }
+
     withName: '.*:BAM_STATS_SAMTOOLS:SAMTOOLS_.*' {
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/samtools_stats" },

--- a/modules/local/star_align_igenomes/main.nf
+++ b/modules/local/star_align_igenomes/main.nf
@@ -27,9 +27,9 @@ process STAR_ALIGN_IGENOMES {
     tuple val(meta), path('*.tab'), optional: true, emit: tab
     tuple val(meta), path('*.out.junction'), optional: true, emit: junction
     tuple val(meta), path('*.out.sam'), optional: true, emit: sam
-    tuple val("${task.process}"), val('star'), eval('STAR --version 2>&1 | sed -e "s/STAR_//g"'), topic: versions, emit: versions_star
-    tuple val("${task.process}"), val('samtools'), eval('echo $(samtools --version 2>&1) | sed "s/^.*samtools //; s/Using.*$//"'), topic: versions, emit: versions_samtools
-    tuple val("${task.process}"), val('gawk'), eval('echo $(gawk --version 2>&1) | sed "s/^.*GNU Awk //; s/, .*$/\1/"'), topic: versions, emit: versions_gawk
+    tuple val("${task.process}"), val('star'), eval('STAR --version | sed "s/STAR_//"'), topic: versions, emit: versions_star
+    tuple val("${task.process}"), val('samtools'), eval("samtools --version | sed -n '1s/samtools //p'"), topic: versions, emit: versions_samtools
+    tuple val("${task.process}"), val('gawk'), eval("gawk --version | sed -n '1s/GNU Awk \\([0-9.]*\\).*/\\1/p'"), topic: versions, emit: versions_gawk
 
     when:
     task.ext.when == null || task.ext.when
@@ -63,5 +63,22 @@ process STAR_ALIGN_IGENOMES {
         mv ${prefix}.Unmapped.out.mate2 ${prefix}.unmapped_2.fastq
         gzip ${prefix}.unmapped_2.fastq
     fi
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo "" | gzip > ${prefix}.unmapped_1.fastq.gz
+    echo "" | gzip > ${prefix}.unmapped_2.fastq.gz
+    touch ${prefix}.Aligned.out.bam
+    touch ${prefix}.Log.final.out
+    touch ${prefix}.Log.out
+    touch ${prefix}.Log.progress.out
+    touch ${prefix}.Aligned.sortedByCoord.out.bam
+    touch ${prefix}.Aligned.toTranscriptome.out.bam
+    touch ${prefix}.Aligned.unsort.out.bam
+    touch ${prefix}.SJ.out.tab
+    touch ${prefix}.Chimeric.out.junction
+    touch ${prefix}.out.sam
     """
 }

--- a/modules/local/star_genomegenerate_igenomes/main.nf
+++ b/modules/local/star_genomegenerate_igenomes/main.nf
@@ -15,9 +15,9 @@ process STAR_GENOMEGENERATE_IGENOMES {
 
     output:
     tuple val(meta), path("star"), emit: index
-    tuple val("${task.process}"), val('star'), eval('STAR --version 2>&1 | sed -e "s/STAR_//g"'), topic: versions, emit: versions_star
-    tuple val("${task.process}"), val('samtools'), eval('echo $(samtools --version 2>&1) | sed "s/^.*samtools //; s/Using.*$//"'), topic: versions, emit: versions_samtools
-    tuple val("${task.process}"), val('gawk'), eval('echo $(gawk --version 2>&1) | sed "s/^.*GNU Awk //; s/, .*$/\1/"'), topic: versions, emit: versions_gawk
+    tuple val("${task.process}"), val('star'), eval('STAR --version | sed "s/STAR_//"'), topic: versions, emit: versions_star
+    tuple val("${task.process}"), val('samtools'), eval("samtools --version | sed -n '1s/samtools //p'"), topic: versions, emit: versions_samtools
+    tuple val("${task.process}"), val('gawk'), eval("gawk --version | sed -n '1s/GNU Awk \\([0-9.]*\\).*/\\1/p'"), topic: versions, emit: versions_gawk
 
     when:
     task.ext.when == null || task.ext.when
@@ -60,4 +60,25 @@ process STAR_GENOMEGENERATE_IGENOMES {
             $args
         """
     }
+
+    stub:
+    """
+    mkdir star
+    touch star/Genome
+    touch star/Log.out
+    touch star/SA
+    touch star/SAindex
+    touch star/chrLength.txt
+    touch star/chrName.txt
+    touch star/chrNameLength.txt
+    touch star/chrStart.txt
+    touch star/exonGeTrInfo.tab
+    touch star/exonInfo.tab
+    touch star/geneInfo.tab
+    touch star/genomeParameters.txt
+    touch star/sjdbInfo.txt
+    touch star/sjdbList.fromGTF.out.tab
+    touch star/sjdbList.out.tab
+    touch star/transcriptInfo.tab
+    """
 }

--- a/subworkflows/local/align_star/meta.yml
+++ b/subworkflows/local/align_star/meta.yml
@@ -1,0 +1,145 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "align_star"
+description: Align reads to a genome with STAR, then sort, index and compute samtools statistics on the resulting alignments
+keywords:
+  - align
+  - star
+  - rnaseq
+  - splicing
+  - bam
+components:
+  - star/align
+  - star_align_igenomes
+  - bam_sort_stats_samtools
+input:
+  - reads:
+      type: file
+      description: |
+        The input channel containing the FastQ reads to align
+        Structure: [ val(meta), path(reads) ]
+      pattern: "*.{fastq,fq}.gz"
+  - index:
+      type: directory
+      description: |
+        The input channel containing the STAR genome index
+        Structure: [ val(meta2), path(index) ]
+  - gtf:
+      type: file
+      description: |
+        The input channel containing the GTF annotation used to extract splice junctions
+        Structure: [ val(meta3), path(gtf) ]
+      pattern: "*.gtf"
+  - star_ignore_sjdbgtf:
+      type: boolean
+      description: |
+        When using pre-built STAR indices do not re-extract and use splice junctions from the GTF file
+        Structure: [ val(star_ignore_sjdbgtf) ]
+  - seq_platform:
+      type: string
+      description: |
+        Sequencing platform written to the BAM read group line, or an empty string to omit it.
+        Only used when `is_aws_igenome` is true
+        Structure: [ val(seq_platform) ]
+  - seq_center:
+      type: string
+      description: |
+        Sequencing center written to the BAM read group line, or an empty string to omit it.
+        Only used when `is_aws_igenome` is true
+        Structure: [ val(seq_center) ]
+  - is_aws_igenome:
+      type: boolean
+      description: |
+        Whether the genome files come from AWS iGenomes, in which case the STAR 2.6.1d based
+        `STAR_ALIGN_IGENOMES` module is used instead of `STAR_ALIGN`
+        Structure: [ val(is_aws_igenome) ]
+  - fasta:
+      type: file
+      description: |
+        The input channel containing the reference genome FASTA and its index, used by samtools
+        Structure: [ val(meta4), path(fasta), path(fai) ]
+      pattern: "*.{fasta,fa}"
+output:
+  - orig_bam:
+      type: file
+      description: |
+        Channel containing the unsorted BAM files as emitted by STAR
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - log_final:
+      type: file
+      description: |
+        Channel containing the STAR final log files
+        Structure: [ val(meta), path(log_final) ]
+      pattern: "*Log.final.out"
+  - log_out:
+      type: file
+      description: |
+        Channel containing the STAR log files
+        Structure: [ val(meta), path(log_out) ]
+      pattern: "*Log.out"
+  - log_progress:
+      type: file
+      description: |
+        Channel containing the STAR progress log files
+        Structure: [ val(meta), path(log_progress) ]
+      pattern: "*Log.progress.out"
+  - bam_sorted:
+      type: file
+      description: |
+        Channel containing the coordinate sorted BAM files, when STAR is asked to sort them
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*sortedByCoord.out.bam"
+  - bam_transcript:
+      type: file
+      description: |
+        Channel containing the transcriptome BAM files, when STAR is run with `--quantMode TranscriptomeSAM`
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*toTranscriptome.out.bam"
+  - fastq:
+      type: file
+      description: |
+        Channel containing the unmapped reads, when STAR is run with `--outReadsUnmapped Fastx`
+        Structure: [ val(meta), path(fastq) ]
+      pattern: "*.fastq.gz"
+  - tab:
+      type: file
+      description: |
+        Channel containing the STAR tab separated output files, such as the splice junction table
+        Structure: [ val(meta), path(tab) ]
+      pattern: "*.tab"
+  - bam:
+      type: file
+      description: |
+        Channel containing the coordinate sorted BAM files produced by samtools
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - index:
+      type: file
+      description: |
+        Channel containing the index of the coordinate sorted BAM files
+        Structure: [ val(meta), path(index) ]
+      pattern: "*.{bai,csi}"
+  - stats:
+      type: file
+      description: |
+        Channel containing the samtools stats output
+        Structure: [ val(meta), path(stats) ]
+      pattern: "*.stats"
+  - flagstat:
+      type: file
+      description: |
+        Channel containing the samtools flagstat output
+        Structure: [ val(meta), path(flagstat) ]
+      pattern: "*.flagstat"
+  - idxstats:
+      type: file
+      description: |
+        Channel containing the samtools idxstats output
+        Structure: [ val(meta), path(idxstats) ]
+      pattern: "*.idxstats"
+authors:
+  - "@bensouthgate"
+  - "@jma1991"
+  - "@piplus2"
+maintainers:
+  - "@piplus2"

--- a/subworkflows/local/align_star/tests/main.nf.test
+++ b/subworkflows/local/align_star/tests/main.nf.test
@@ -1,0 +1,351 @@
+// nf-core subworkflows test align_star
+nextflow_workflow {
+
+    name "Test Subworkflow ALIGN_STAR"
+    script "../main.nf"
+    workflow "ALIGN_STAR"
+
+    tag "subworkflows"
+    tag "subworkflows/align_star"
+    tag "star"
+    tag "star/align"
+    tag "star/genomegenerate"
+    tag "star_align_igenomes"
+    tag "star_genomegenerate_igenomes"
+    tag "subworkflows/bam_sort_stats_samtools"
+    tag "samtools"
+    tag "samtools/sort"
+    tag "samtools/index"
+    tag "samtools/stats"
+    tag "samtools/flagstat"
+    tag "samtools/idxstats"
+
+    test("homo_sapiens - paired_end") {
+
+        setup {
+            run("STAR_GENOMEGENERATE") {
+                script "../../../../modules/nf-core/star/genomegenerate/main.nf"
+                process {
+                    """
+                    input[0] = channel.of([
+                        [ id:'test_fasta' ],
+                        [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
+                    ])
+                    input[1] = channel.of([
+                        [ id:'test_gtf' ],
+                        [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
+                    ])
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:false ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = STAR_GENOMEGENERATE.out.index
+                input[2] = channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = false
+                input[4] = ''
+                input[5] = ''
+                input[6] = false
+                input[7] = channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.orig_bam.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.bam_transcript.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.bam.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.index.collect { meta, idx -> [ meta, file(idx).name ] },
+                    workflow.out.log_final.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.log_out.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.log_progress.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.bam_sorted,
+                    workflow.out.fastq,
+                    workflow.out.tab,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - single_end") {
+
+        setup {
+            run("STAR_GENOMEGENERATE") {
+                script "../../../../modules/nf-core/star/genomegenerate/main.nf"
+                process {
+                    """
+                    input[0] = channel.of([
+                        [ id:'test_fasta' ],
+                        [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
+                    ])
+                    input[1] = channel.of([
+                        [ id:'test_gtf' ],
+                        [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
+                    ])
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true) ]
+                ])
+                input[1] = STAR_GENOMEGENERATE.out.index
+                input[2] = channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = false
+                input[4] = ''
+                input[5] = ''
+                input[6] = false
+                input[7] = channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.orig_bam.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.bam_transcript.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.bam.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.index.collect { meta, idx -> [ meta, file(idx).name ] },
+                    workflow.out.log_final.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.log_out.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.log_progress.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.bam_sorted,
+                    workflow.out.fastq,
+                    workflow.out.tab,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - paired_end - igenomes") {
+
+        setup {
+            run("STAR_GENOMEGENERATE_IGENOMES") {
+                script "../../../../modules/local/star_genomegenerate_igenomes/main.nf"
+                process {
+                    """
+                    input[0] = channel.of([
+                        [ id:'test_fasta' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                    ])
+                    input[1] = channel.of([
+                        [ id:'test_gtf' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                    ])
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:false ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = STAR_GENOMEGENERATE_IGENOMES.out.index
+                input[2] = channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = false
+                input[4] = 'illumina'
+                input[5] = 'sequencing_center'
+                input[6] = true
+                input[7] = channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.orig_bam.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.bam_transcript.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.bam.collect { meta, bam_file -> [ meta, file(bam_file).name ] },
+                    workflow.out.index.collect { meta, idx -> [ meta, file(idx).name ] },
+                    workflow.out.log_final.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.log_out.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.log_progress.collect { meta, log_file -> [ meta, file(log_file).name ] },
+                    workflow.out.bam_sorted,
+                    workflow.out.fastq,
+                    workflow.out.tab,
+                    workflow.out.stats,
+                    workflow.out.flagstat,
+                    workflow.out.idxstats
+                ).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - paired_end - stub") {
+
+        options "-stub"
+
+        setup {
+            run("STAR_GENOMEGENERATE") {
+                script "../../../../modules/nf-core/star/genomegenerate/main.nf"
+                process {
+                    """
+                    input[0] = channel.of([
+                        [ id:'test_fasta' ],
+                        [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
+                    ])
+                    input[1] = channel.of([
+                        [ id:'test_gtf' ],
+                        [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
+                    ])
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:false ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = STAR_GENOMEGENERATE.out.index
+                input[2] = channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = false
+                input[4] = ''
+                input[5] = ''
+                input[6] = false
+                input[7] = channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(sanitizeOutput(workflow.out)).match() }
+            )
+        }
+
+    }
+
+    test("homo_sapiens - paired_end - igenomes - stub") {
+
+        options "-stub"
+
+        setup {
+            run("STAR_GENOMEGENERATE_IGENOMES") {
+                script "../../../../modules/local/star_genomegenerate_igenomes/main.nf"
+                process {
+                    """
+                    input[0] = channel.of([
+                        [ id:'test_fasta' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                    ])
+                    input[1] = channel.of([
+                        [ id:'test_gtf' ],
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                    ])
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:false ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = STAR_GENOMEGENERATE_IGENOMES.out.index
+                input[2] = channel.of([
+                    [ id:'test_gtf' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                ])
+                input[3] = false
+                input[4] = 'illumina'
+                input[5] = 'sequencing_center'
+                input[6] = true
+                input[7] = channel.of([
+                    [ id:'test_fasta' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(sanitizeOutput(workflow.out)).match() }
+            )
+        }
+
+    }
+
+}

--- a/subworkflows/local/align_star/tests/main.nf.test.snap
+++ b/subworkflows/local/align_star/tests/main.nf.test.snap
@@ -1,0 +1,617 @@
+{
+    "homo_sapiens - paired_end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Aligned.out.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Aligned.toTranscriptome.out.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_sorted.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_sorted.bam.bai"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Log.final.out"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Log.out"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Log.progress.out"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.SJ.out.tab:md5,8fc5e816356f0d2ac204ccd6f992d585"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.stats:md5,b40781c126328ebcd0f209c1e22b22b0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.flagstat:md5,8de6dfd4e5bd8e8ab814b4af205a99cf"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.idxstats:md5,f5f72b9d9be840430a7fa3f0d0cdacd0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-07T09:35:43.224979579",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "homo_sapiens - single_end": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.Aligned.out.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.Aligned.toTranscriptome.out.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_sorted.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_sorted.bam.bai"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.Log.final.out"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.Log.out"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.Log.progress.out"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.SJ.out.tab:md5,3e7f6a2addb56276951bcc553236da1c"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.stats:md5,f68e9d9ffd77e83e0395694cca2c1222"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.flagstat:md5,ede5cfd0e631106ac43a50b5a763a4ce"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.idxstats:md5,a6baa4e4a77db26c7338fc583f9d99a5"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-07T09:35:52.002439617",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "homo_sapiens - paired_end - stub": {
+        "content": [
+            {
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_sorted.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam_sorted": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam_transcript": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.toTranscriptome.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fastq": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.unmapped_1.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.unmapped_2.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "flagstat": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.flagstat:md5,67394650dbae96d1a4fcc70484822159"
+                    ]
+                ],
+                "idxstats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_sorted.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_final": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.final.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_progress": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.progress.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "orig_bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.Aligned.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "testXd.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tab": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.ReadsPerGene.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.SJ.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.tab:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-07T09:36:44.924731086",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "homo_sapiens - paired_end - igenomes": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Aligned.out.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Aligned.toTranscriptome.out.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_sorted.bam"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_sorted.bam.bai"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Log.final.out"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Log.out"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.Log.progress.out"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.SJ.out.tab:md5,8fc5e816356f0d2ac204ccd6f992d585"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.stats:md5,b40781c126328ebcd0f209c1e22b22b0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.flagstat:md5,8de6dfd4e5bd8e8ab814b4af205a99cf"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.idxstats:md5,f5f72b9d9be840430a7fa3f0d0cdacd0"
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-07T09:36:37.994002706",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "homo_sapiens - paired_end - igenomes - stub": {
+        "content": [
+            {
+                "bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_sorted.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam_sorted": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Aligned.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "bam_transcript": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Aligned.toTranscriptome.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fastq": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.unmapped_1.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
+                            "test.unmapped_2.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        ]
+                    ]
+                ],
+                "flagstat": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.flagstat:md5,67394650dbae96d1a4fcc70484822159"
+                    ]
+                ],
+                "idxstats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.idxstats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "index": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_sorted.bam.bai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_final": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.final.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_out": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log_progress": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.Log.progress.out:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "orig_bam": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test.Aligned.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "test.Aligned.sortedByCoord.out.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tab": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.SJ.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-09-07T09:36:53.590347562",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the local `ALIGN_STAR` subworkflow to the nf-core subworkflow structure, adding a `meta.yml` and nf-test coverage. Continues the refactoring series (#250 did the same for `VISUALISE_MISO`).

### Added

- `subworkflows/local/align_star/meta.yml` documenting all 8 inputs and 13 outputs.
- `subworkflows/local/align_star/tests/main.nf.test` with 5 tests: paired-end, single-end, iGenomes paired-end, and stub runs for both the `STAR_ALIGN` and the `STAR_ALIGN_IGENOMES` branches.

No new test data was needed. The tests reuse the existing nf-core modules test-datasets (`genomics/homo_sapiens/genome/genome.{fasta,fasta.fai,gtf}` and `illumina/fastq/test_rnaseq_{1,2}.fastq.gz`), the same set `star/align` already uses, and build the STAR index in a `setup {}` block so no index has to be stored.

Snapshots assert file names for the BAMs and STAR logs (their headers and contents carry work-directory paths and timings) and full content for `stats`/`flagstat`/`idxstats`, which is where the alignment content is actually verified. The snapshots were confirmed stable across three consecutive runs.

### Fixed

Writing the tests surfaced three pre-existing bugs that made the iGenomes alignment path unrunnable:

- The software version `eval` commands of `STAR_ALIGN_IGENOMES` and `STAR_GENOMEGENERATE_IGENOMES` failed with a shell syntax error (`bash: -c: line 2: syntax error near unexpected token 'C'`) and aborted both processes. They now follow the nf-core `star/align` patterns.
- `conf/modules.config` applied `--quantTranscriptomeSAMoutput BanSingleEnd` to both `STAR_ALIGN` and `STAR_ALIGN_IGENOMES` through a shared `withName` selector. `STAR_ALIGN_IGENOMES` pins STAR 2.6.1d, which predates that option and exits with `FATAL INPUT ERROR: unrecoginzed parameter name "quantTranscriptomeSAMoutput"`. A dedicated `withName: 'STAR_ALIGN_IGENOMES'` block now uses the equivalent legacy `--quantTranscriptomeBan Singleend`. `STAR_ALIGN` is unchanged. This traces back to the rename in #195.
- Neither iGenomes module had a stub section; both now have one.

## Testing

```
nf-test test subworkflows/local/align_star/tests/main.nf.test --profile=+docker
SUCCESS: Executed 5 tests in 112.595s
```

`prettier` and `nextflow lint` are clean on the changed files.

Two checks were **not** run locally, and are left to CI:

- The full pipeline test (`nextflow run . -profile test,docker`) was not run. The default `test` profile does not exercise the iGenomes path (`is_aws_igenome` is false), so the `conf/modules.config` change is not covered by it; the new `homo_sapiens - paired_end - igenomes` nf-test covers that path instead.
- `nf-core pipelines lint` could not be run: it crashes with `IndexError: string index out of range` in `nf_core/pipelines/lint/files_exist.py:201` on nf-core/tools 4.1.0. The crash reproduces unchanged on `f1c4fa7` (the commit before this branch), so it is unrelated to these changes.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Make sure your code lints (`nf-core pipelines lint`) — see the note above, the linter crashes on this repo independently of this PR.
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`) — not run locally, see the note above.
- [x] `CHANGELOG.md` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZ59LJfCyxL93VrDXEY3Cn
