### PR TITLE
Port edger_deu subworkflow to the nf-core structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #261 - The pipeline parses the samplesheet and the contrastsheet once each, in `PIPELINE_INITIALISATION` (by @piplus2)
 - #261 - Remove the unused `INPUT_CHECK` subworkflow (by @piplus2)
 - #264 - Move the `DRIMSEQ_DEXSEQ_DTU` subworkflow to the nf-core subworkflow template (by @piplus2)
+- #268 - Move the `EDGER_DEU` subworkflow to the nf-core subworkflow template. It now emits the `EDGER_EXON` results and the featureCounts tables, which it ran but discarded (by @piplus2)
 
 ### Fixed
 

--- a/subworkflows/local/edger_deu/main.nf
+++ b/subworkflows/local/edger_deu/main.nf
@@ -2,9 +2,9 @@
 // edgeR DEU subworkflow
 //
 
-include { SUBREAD_FLATTENGTF    } from '../../../modules/local/subread/flattengtf'
+include { SUBREAD_FLATTENGTF } from '../../../modules/local/subread/flattengtf'
 include { SUBREAD_FEATURECOUNTS } from '../../../modules/nf-core/subread/featurecounts'
-include { EDGER_EXON            } from '../../../modules/local/edger/exon'
+include { EDGER_EXON } from '../../../modules/local/edger/exon'
 
 workflow EDGER_DEU {
     take:
@@ -15,9 +15,11 @@ workflow EDGER_DEU {
 
     main:
 
+    //
     // MODULE: SUBREAD_FLATTENGTF
+    //
 
-    SUBREAD_FLATTENGTF(gtf.map { file -> [ [id: file.baseName], file ] })
+    SUBREAD_FLATTENGTF(gtf.map { file -> [[id: file.baseName], file] })
 
     //
     // MODULE: SUBREAD_FEATURECOUNTS
@@ -28,19 +30,26 @@ workflow EDGER_DEU {
     SUBREAD_FEATURECOUNTS(ch_feature_counts)
 
     //
-    // MODULE: EDGER_COUNTS AND PLOT
+    // MODULE: EDGER_EXON
     //
+
     ch_feature_counts_collected = SUBREAD_FEATURECOUNTS.out.counts
         .map { _meta, counts -> counts }
         .collect()
-        .map { counts -> [ [ id: 'edger_exon' ], counts ] }
+        .map { counts -> [[id: 'edger_exon'], counts] }
 
     EDGER_EXON(
         ch_feature_counts_collected,
-        ch_samplesheet.map { samplesheet -> [ [ id: samplesheet.baseName ], samplesheet ] },
-        ch_contrastsheet.map { contrastsheet -> [ [ id: contrastsheet.baseName ], contrastsheet ] },
+        ch_samplesheet.map { samplesheet -> [[id: samplesheet.baseName], samplesheet] },
+        ch_contrastsheet.map { contrastsheet -> [[id: contrastsheet.baseName], contrastsheet] },
     )
 
     emit:
-    featureCounts_summary = SUBREAD_FEATURECOUNTS.out.summary // path featureCounts.txt.summary
+    featureCounts_counts = SUBREAD_FEATURECOUNTS.out.counts // channel: [ val(meta), path(counts) ]
+    featureCounts_summary = SUBREAD_FEATURECOUNTS.out.summary // channel: [ val(meta), path(summary) ]
+    edger_exon_dge = EDGER_EXON.out.edger_exon_dge // channel: [ val(meta), path(rds) ]
+    edger_exon_glm = EDGER_EXON.out.edger_exon_glm // channel: [ val(meta), path(rds) ]
+    edger_exon_lrt = EDGER_EXON.out.edger_exon_lrt // channel: [ val(meta), path(rds) ]
+    edger_exon_csv = EDGER_EXON.out.edger_exon_csv // channel: [ val(meta), path(csv) ]
+    edger_exon_pdf = EDGER_EXON.out.edger_exon_pdf // channel: [ val(meta), path(pdf) ]
 }

--- a/subworkflows/local/edger_deu/meta.yml
+++ b/subworkflows/local/edger_deu/meta.yml
@@ -1,0 +1,91 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "edger_deu"
+description: Flatten a GTF annotation into exonic features, count reads per feature in each sample and test for differential exon usage and expression with edgeR
+keywords:
+  - edger
+  - deu
+  - differential exon usage
+  - splicing
+  - featurecounts
+components:
+  - subread/flattengtf
+  - subread/featurecounts
+  - edger/exon
+input:
+  - gtf:
+      type: file
+      description: |
+        The input channel containing the GTF annotation to flatten into exonic features
+        Structure: [ path(gtf) ]
+      pattern: "*.gtf"
+  - ch_genome_bam:
+      type: file
+      description: |
+        The input channel containing the genome BAM files to count reads from. The `strandedness`
+        and `single_end` keys of the meta map determine how `SUBREAD_FEATURECOUNTS` counts them
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - ch_samplesheet:
+      type: file
+      description: |
+        The input channel containing the samplesheet, which assigns each sample to a condition
+        Structure: [ path(samplesheet) ]
+      pattern: "*.csv"
+  - ch_contrastsheet:
+      type: file
+      description: |
+        The input channel containing the contrastsheet, which lists the conditions to compare
+        Structure: [ path(contrastsheet) ]
+      pattern: "*.csv"
+output:
+  - featureCounts_counts:
+      type: file
+      description: |
+        Channel containing the per sample exonic feature count tables
+        Structure: [ val(meta), path(counts) ]
+      pattern: "*.featureCounts.tsv"
+  - featureCounts_summary:
+      type: file
+      description: |
+        Channel containing the per sample featureCounts assignment summaries, which are
+        collected for MultiQC
+        Structure: [ val(meta), path(summary) ]
+      pattern: "*.featureCounts.tsv.summary"
+  - edger_exon_dge:
+      type: file
+      description: |
+        Channel containing the `DGEList` object holding the counts of every sample
+        Structure: [ val(meta), path(rds) ]
+      pattern: "DGEList.rds"
+  - edger_exon_glm:
+      type: file
+      description: |
+        Channel containing the `DGEGLM` object holding the fitted model
+        Structure: [ val(meta), path(rds) ]
+      pattern: "DGEGLM.rds"
+  - edger_exon_lrt:
+      type: file
+      description: |
+        Channel containing the `DGELRT` objects of the exon expression and exon usage tests
+        Structure: [ val(meta), path(rds) ]
+      pattern: "DGELRT.*.rds"
+  - edger_exon_csv:
+      type: file
+      description: |
+        Channel containing the exon expression results and the exon usage results per contrast,
+        the latter at simes, gene and exon level
+        Structure: [ val(meta), path(csv) ]
+      pattern: "contrast_*.csv"
+  - edger_exon_pdf:
+      type: file
+      description: |
+        Channel containing the exon usage plots of the top significant genes per contrast
+        Structure: [ val(meta), path(pdf) ]
+      pattern: "contrast_*.pdf"
+authors:
+  - "@bensouthgate"
+  - "@jma1991"
+  - "@valentinoruggieri"
+  - "@piplus2"
+maintainers:
+  - "@piplus2"

--- a/subworkflows/local/edger_deu/tests/main.nf.test
+++ b/subworkflows/local/edger_deu/tests/main.nf.test
@@ -1,0 +1,93 @@
+// nf-core subworkflows test edger_deu
+nextflow_workflow {
+
+    name "Test Subworkflow EDGER_DEU"
+    script "../main.nf"
+    workflow "EDGER_DEU"
+
+    tag "subworkflows"
+    tag "subworkflows/edger_deu"
+    tag "subread"
+    tag "subread/flattengtf"
+    tag "subread/featurecounts"
+    tag "edger"
+    tag "edger/exon"
+
+    test("human chrX") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.value(file(params.pipelines_testdata_base_path + 'reference/genes_chrX.gtf', checkIfExists: true))
+                input[1] = channel.of(
+                    [ [ id:'ERR188383', single_end:false, strandedness:'unstranded' ], file(params.pipelines_testdata_base_path + 'testdata/ERR188383.Aligned.out.bam', checkIfExists: true) ],
+                    [ [ id:'ERR188428', single_end:false, strandedness:'unstranded' ], file(params.pipelines_testdata_base_path + 'testdata/ERR188428.Aligned.out.bam', checkIfExists: true) ],
+                    [ [ id:'ERR188454', single_end:false, strandedness:'unstranded' ], file(params.pipelines_testdata_base_path + 'testdata/ERR188454.Aligned.out.bam', checkIfExists: true) ],
+                    [ [ id:'ERR204916', single_end:false, strandedness:'unstranded' ], file(params.pipelines_testdata_base_path + 'testdata/ERR204916.Aligned.out.bam', checkIfExists: true) ],
+                )
+                input[2] = channel.value(file(params.pipelines_testdata_base_path + 'samplesheet/samplesheet.csv', checkIfExists: true))
+                input[3] = channel.value(file(params.pipelines_testdata_base_path + 'samplesheet/contrastsheet.csv', checkIfExists: true))
+                """
+            }
+        }
+
+        then {
+            // `SUBREAD_FEATURECOUNTS` runs once per sample, so its channels follow task
+            // completion order and have to be sorted before they can be snapshotted.
+            //
+            // The exon usage tables are snapshotted by content, the exon expression tables,
+            // the plots and the binary objects by name only, following the split the
+            // `EDGER_EXON` module test already establishes
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.featureCounts_summary.sort { summary -> summary[0].id },
+                    workflow.out.featureCounts_counts.collect { meta, counts -> [ meta, file(counts).name ] }.sort { counts -> counts[0].id },
+                    workflow.out.edger_exon_csv.collect { meta, csvs -> [ meta, csvs.findAll { csv -> csv.contains('.usage.') } ] },
+                    workflow.out.edger_exon_csv.collect { meta, csvs -> [ meta, csvs.findAll { csv -> csv.endsWith('.exprs.csv') }.collect { csv -> file(csv).name } ] },
+                    workflow.out.edger_exon_pdf.collect { meta, pdfs -> [ meta, pdfs.collect { pdf -> file(pdf).name } ] },
+                    workflow.out.edger_exon_dge.collect { meta, rds -> [ meta, file(rds).name ] },
+                    workflow.out.edger_exon_glm.collect { meta, rds -> [ meta, file(rds).name ] },
+                    workflow.out.edger_exon_lrt.collect { meta, rds -> [ meta, rds.collect { r -> file(r).name } ] }
+                ).match() }
+            )
+        }
+
+    }
+
+    test("human chrX - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.value(file(params.pipelines_testdata_base_path + 'reference/genes_chrX.gtf', checkIfExists: true))
+                input[1] = channel.of(
+                    [ [ id:'ERR188383', single_end:false, strandedness:'unstranded' ], file(params.pipelines_testdata_base_path + 'testdata/ERR188383.Aligned.out.bam', checkIfExists: true) ],
+                    [ [ id:'ERR188428', single_end:false, strandedness:'unstranded' ], file(params.pipelines_testdata_base_path + 'testdata/ERR188428.Aligned.out.bam', checkIfExists: true) ],
+                )
+                input[2] = channel.value(file(params.pipelines_testdata_base_path + 'samplesheet/samplesheet.csv', checkIfExists: true))
+                input[3] = channel.value(file(params.pipelines_testdata_base_path + 'samplesheet/contrastsheet.csv', checkIfExists: true))
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.featureCounts_counts.sort { counts -> counts[0].id },
+                    workflow.out.featureCounts_summary.sort { summary -> summary[0].id },
+                    workflow.out.edger_exon_dge,
+                    workflow.out.edger_exon_glm,
+                    workflow.out.edger_exon_lrt,
+                    workflow.out.edger_exon_csv,
+                    workflow.out.edger_exon_pdf
+                ).match() }
+            )
+        }
+
+    }
+
+}

--- a/subworkflows/local/edger_deu/tests/main.nf.test.snap
+++ b/subworkflows/local/edger_deu/tests/main.nf.test.snap
@@ -1,0 +1,251 @@
+{
+    "human chrX": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "ERR188383",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188383.featureCounts.tsv.summary:md5,c8e40fac34d9cab0cddf744feea72622"
+                ],
+                [
+                    {
+                        "id": "ERR188428",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188428.featureCounts.tsv.summary:md5,a17f623b6862384fc9f54ebdd4286b66"
+                ],
+                [
+                    {
+                        "id": "ERR188454",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188454.featureCounts.tsv.summary:md5,2868e96d572ae0e9a1ea1129a8d1676d"
+                ],
+                [
+                    {
+                        "id": "ERR204916",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR204916.featureCounts.tsv.summary:md5,a7f693e0186f00a14a698175ee39c8ec"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ERR188383",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188383.featureCounts.tsv"
+                ],
+                [
+                    {
+                        "id": "ERR188428",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188428.featureCounts.tsv"
+                ],
+                [
+                    {
+                        "id": "ERR188454",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188454.featureCounts.tsv"
+                ],
+                [
+                    {
+                        "id": "ERR204916",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR204916.featureCounts.tsv"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "contrast_GBR-YRI.usage.exon.csv:md5,f102b5c2619cd811ddc04d7569b797ba",
+                        "contrast_GBR-YRI.usage.gene.csv:md5,8ebb5e11ba7a4c63ab56f9a61f9eccb6",
+                        "contrast_GBR-YRI.usage.simes.csv:md5,13a3730955b862752c2b0a08b9415280",
+                        "contrast_YRI-GBR.usage.exon.csv:md5,11c3f911f66d62b24b9dc048891a37f9",
+                        "contrast_YRI-GBR.usage.gene.csv:md5,586b678f3ae96e383a5456e42c37e6a9",
+                        "contrast_YRI-GBR.usage.simes.csv:md5,f1715819025c665bc1ba08bcfab4a3a3"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "contrast_GBR-YRI.exprs.csv",
+                        "contrast_YRI-GBR.exprs.csv"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "contrast_GBR-YRI.usage.exon.pdf",
+                        "contrast_GBR-YRI.usage.gene.pdf",
+                        "contrast_GBR-YRI.usage.simes.pdf",
+                        "contrast_YRI-GBR.usage.exon.pdf",
+                        "contrast_YRI-GBR.usage.gene.pdf",
+                        "contrast_YRI-GBR.usage.simes.pdf"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    "DGEList.rds"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    "DGEGLM.rds"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "DGELRT.exprs.rds",
+                        "DGELRT.usage.rds"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-10T11:28:18.249049892",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "human chrX - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "ERR188383",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188383.featureCounts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                [
+                    {
+                        "id": "ERR188428",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188428.featureCounts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ERR188383",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188383.featureCounts.tsv.summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ],
+                [
+                    {
+                        "id": "ERR188428",
+                        "single_end": false,
+                        "strandedness": "unstranded"
+                    },
+                    "ERR188428.featureCounts.tsv.summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    "DGEList.rds:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    "DGEGLM.rds:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "DGELRT.exprs.rds:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "DGELRT.usage.rds:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "contrast_GBR-YRI.exprs.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_GBR-YRI.usage.exon.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_GBR-YRI.usage.gene.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_GBR-YRI.usage.simes.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.exprs.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.usage.exon.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.usage.gene.csv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.usage.simes.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "edger_exon"
+                    },
+                    [
+                        "contrast_GBR-YRI.usage.exon.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_GBR-YRI.usage.gene.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_GBR-YRI.usage.simes.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.usage.exon.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.usage.gene.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "contrast_YRI-GBR.usage.simes.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ]
+        ],
+        "timestamp": "2026-09-10T11:28:26.873704515",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}


### PR DESCRIPTION
Closes #268.

## Summary

Ports the local `EDGER_DEU` subworkflow to the nf-core subworkflow structure, adding a `meta.yml` and nf-test coverage, and emits the edgeR results the subworkflow was computing and throwing away. Continues the refactoring series (#250 did this for `VISUALISE_MISO`, #256 for `ALIGN_STAR`, #257 for `DEXSEQ_DEU`, #264 for `DRIMSEQ_DEXSEQ_DTU`).

No new test-datasets files were needed.

### Added

- `subworkflows/local/edger_deu/meta.yml` documenting the 4 inputs and the 7 outputs.
- `subworkflows/local/edger_deu/tests/main.nf.test` with a real run and a stub run, over `reference/genes_chrX.gtf`, the four `testdata/ERR*.Aligned.out.bam` files and `samplesheet/samplesheet.csv` plus `samplesheet/contrastsheet.csv`, the same fixtures the `EDGER_EXON` module test uses.

### Changed

- The subworkflow emits the `EDGER_EXON` outputs (`DGEList`, `DGEGLM`, the `DGELRT` objects, and the per contrast tables and plots) and the featureCounts count tables, alongside the summaries it already emitted.

  It ran `EDGER_EXON` and forwarded nothing from it. The only emission was `featureCounts_summary`, which exists for MultiQC, so the entire edgeR result was reachable only through `publishDir`, and a subworkflow test could assert on nothing but the read assignment summaries of a step that is not what this subworkflow is for. The change is additive: `workflows/rnasplice.nf` reads only `featureCounts_summary`, which keeps its name.

- `subworkflows/local/edger_deu/main.nf` reformatted with `nextflow lint -format`, and `SUBREAD_FLATTENGTF` and `EDGER_EXON` given the same `MODULE:` header style as their neighbours. Behaviour is unchanged.

## Note on the snapshots

Following the trouble in #265, what is snapshotted by content is deliberate rather than whatever happened to be reproducible on one machine:

- The featureCounts **count tables** are snapshotted by name. Their first line carries the featureCounts command, including `"-T"` and the cpu count, so the checksum follows the executor rather than the data:

  ```
  # Program:featureCounts v2.1.1; Command:"featureCounts" "-F" "SAF" ... "-T" "4" "-a" "genes_chrX.saf" ...
  ```

- The featureCounts **summaries** are snapshotted by content. They carry no such header, only `Status <bam>` and integers.

- For the edgeR outputs the split follows the `EDGER_EXON` module test: the exon usage tables by content, the exon expression tables, the plots and the RDS objects by name. The usage table checksums recorded here are identical to the ones in that module's snapshot, which passes in CI, so they are known good across machines rather than merely stable on mine.

- `SUBREAD_FEATURECOUNTS` runs once per sample, so its channels come back in task completion order and are sorted by `meta.id` in the assertions.

## Testing

```
nf-test test subworkflows/local/edger_deu/tests/main.nf.test --profile=+docker
SUCCESS: Executed 2 tests in 24.025s   # recording the snapshot
SUCCESS: Executed 2 tests in 18.067s   # verifying it unchanged
```

`prettier` is clean, and `nextflow lint` is clean on both 26.04 and 26.08-edge. The pipeline level tests are left to CI.

Rebased on `dev` after #265 merged, which also resolved a `CHANGELOG.md` conflict with it. Worth recording why: while the conflict stood, GitHub could not build the merge ref, so it ran no workflows at all on this PR and the only check present was Graphite's. The `latest-everything` warning that #265 carried is gone with it, as the `SPLIT_FILES` fix (#267) is now in `dev`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`) — passing in CI.
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`) — run by CI.
- [x] `CHANGELOG.md` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkV2YDYH4kJrtUzWqyMZwr

